### PR TITLE
Rename TopLevel Gem Module to SendGridRails

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@ In your Gemfile:
 
 In config/initializers/mail.rb:
 
-    ActionMailer::Base.register_interceptor(SendGrid::MailInterceptor)
+    ActionMailer::Base.register_interceptor(SendGridRails::MailInterceptor)
     
     ActionMailer::Base.smtp_settings = {
       :address => 'smtp.sendgrid.net',
@@ -30,7 +30,7 @@ In config/initializers/mail.rb:
 
 If you use Heroku, here what the mailer initializer may look like:
 
-    ActionMailer::Base.register_interceptor(SendGrid::MailInterceptor)
+    ActionMailer::Base.register_interceptor(SendGridRails::MailInterceptor)
     
     if ENV['SENDGRID_USERNAME'] && ENV['SENDGRID_PASSWORD']
       ActionMailer::Base.smtp_settings = {
@@ -53,7 +53,7 @@ By default set to 'dummy@email.com'
 
 In config/initializers/mail.rb:
 
-    SendGrid.configure do |config|
+    SendGridRails.configure do |config|
       config.dummy_recipient = 'noreply@example.com'
     end
 

--- a/lib/send_grid.rb
+++ b/lib/send_grid.rb
@@ -1,4 +1,4 @@
-module SendGrid
+module SendGridRails
   autoload :ApiHeader, 'send_grid/api_header'
   autoload :MailInterceptor, 'send_grid/mail_interceptor'
   autoload :VERSION, 'send_grid/version'
@@ -15,7 +15,7 @@ module SendGrid
 
   module InstanceMethods
     def send_grid_header
-      @send_grid_header ||= SendGrid::ApiHeader.new
+      @send_grid_header ||= SendGridRails::ApiHeader.new
     end
 
     def mail(headers={}, &block)
@@ -33,7 +33,7 @@ module SendGrid
     attr_writer :config
 
     def config
-      @config ||= SendGrid::Config.new
+      @config ||= SendGridRails::Config.new
     end
 
     # Sendgrid.config will be default if block is not passed

--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -1,4 +1,4 @@
-class SendGrid::ApiHeader
+class SendGridRails::ApiHeader
   attr_reader :data
 
   def initialize

--- a/lib/send_grid/config.rb
+++ b/lib/send_grid/config.rb
@@ -1,4 +1,4 @@
-class SendGrid::Config
+class SendGridRails::Config
   attr_accessor :dummy_recipient
 
   def initialize

--- a/lib/send_grid/mail_interceptor.rb
+++ b/lib/send_grid/mail_interceptor.rb
@@ -1,4 +1,4 @@
-module SendGrid
+module SendGridRails
   class MailInterceptor
     def self.delivering_email(mail)
       sendgrid_header = mail.instance_variable_get(:@sendgrid_header)

--- a/lib/send_grid/version.rb
+++ b/lib/send_grid/version.rb
@@ -1,4 +1,3 @@
-module SendGrid
-  VERSION = "3.1.0"
+module SendGridRails
+  VERSION = '3.1.0'
 end
-

--- a/lib/sendgrid-rails.rb
+++ b/lib/sendgrid-rails.rb
@@ -3,4 +3,4 @@ require 'active_support'
 require 'active_support/core_ext'
 require 'action_mailer'
 
-ActionMailer::Base.send :include, SendGrid
+ActionMailer::Base.send :include, SendGridRails

--- a/send_grid.gemspec
+++ b/send_grid.gemspec
@@ -4,7 +4,7 @@ require "send_grid/version"
 
 Gem::Specification.new do |s|
   s.name        = "sendgrid-rails"
-  s.version     = SendGrid::VERSION
+  s.version     = SendGridRails::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["PavelTyk"]
   s.email       = ["paveltyk@gmail.com"]

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe SendGrid::ApiHeader do
-  let(:header) { SendGrid::ApiHeader.new }
+describe SendGridRails::ApiHeader do
+  let(:header) { SendGridRails::ApiHeader.new }
   describe "#to_json" do
     it "returns valid json if no data was set" do
       header.to_json.should eql "{}"

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -54,7 +54,7 @@ describe Mailer do
     it 'should be used in To defined in config dummy_recipient' do
       # dummy_recipient can be redefined config/initializers
 
-      SendGrid.configure do |config|
+      SendGridRails.configure do |config|
         config.dummy_recipient = 'noreply@example.com'
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'sendgrid-rails'
 
-ActionMailer::Base.register_interceptor(SendGrid::MailInterceptor)
+ActionMailer::Base.register_interceptor(SendGridRails::MailInterceptor)
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.prepend_view_path File.join(File.dirname(__FILE__), "fixtures", "views")
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe 'SendGrid::VERSION' do
+describe 'SendGridRails::VERSION' do
   it "returns string" do
-    SendGrid::VERSION.should be_an_instance_of(String)
+    SendGridRails::VERSION.should be_an_instance_of(String)
   end
 end
 


### PR DESCRIPTION
- module name conflicts with the gem sendgrid-ruby
- this is the smaller gem and requires less changes